### PR TITLE
Optimize gaps for RangeSet containing only one range

### DIFF
--- a/lib/range_set.ex
+++ b/lib/range_set.ex
@@ -66,9 +66,14 @@ defmodule RangeSet do
   ```elixir
   iex> #{inspect(__MODULE__)}.new([0..2, 6..9]) |> #{inspect(__MODULE__)}.gaps()
   #{inspect(__MODULE__)}.new([3..5])
+
+  iex> #{inspect(__MODULE__)}.new([0..5, 6..9]) |> #{inspect(__MODULE__)}.gaps()
+  #{inspect(__MODULE__)}.new([])
   ```
   """
   @spec gaps(t()) :: t()
+  def gaps(%__MODULE__{ranges: [_range]}), do: %__MODULE__{ranges: []}
+
   def gaps(%__MODULE__{ranges: ranges}) do
     gaps =
       ranges


### PR DESCRIPTION
When there's only one range in the RangeSet, we can't have any gaps.

This is assuming the ranges are all step 1, which is an assumption the rest of the library makes as well.

In this benchmark, the existing code is `gaps` while the optimized code is `gaps2`, calling `RangeSet.gaps` on `RangeSet.new([0..5])`

```
Benchmarking gaps ...
Benchmarking gaps2 ...

Name            ips        average  deviation         median         99th %
gaps2        1.51 M      661.25 ns  ±8748.49%         434 ns         850 ns
gaps         1.06 M      942.80 ns  ±7265.27%         642 ns        1176 ns

Comparison: 
gaps2        1.51 M
gaps         1.06 M - 1.43x slower +281.55 ns

Memory usage statistics:

Name     Memory usage
gaps2         0.54 KB
gaps          1.02 KB - 1.90x memory usage +0.48 KB
```